### PR TITLE
Handle non-x86 kselftest arch

### DIFF
--- a/kselftests.sh
+++ b/kselftests.sh
@@ -12,8 +12,25 @@ else
 	/etc/init.d/net.$ETH start
 fi
 
-# TODO move this in rootfs generation
-wget http://storage.kernelci.org/images/selftests/x86/kselftest.tar.gz
-tar xzf kselftest.tar.gz
+if [ ! -e /root/kselftest.tar.gz ];then
+	case $(uname -m) in
+	aarch64)
+		KSARCH=arm64
+	;;
+	x86_64)
+		KSARCH=x86
+	;;
+	armv7l)
+		KSARCH=arm
+	;;
+	*)
+		echo "SKIP: no kselftests for $(uname -m) arch"
+		exit 0
+	;;
+	esac
+	# TODO move this in rootfs generation
+	wget http://storage.kernelci.org/images/selftests/$KSARCH/kselftest.tar.gz
+fi
+tar xzf kselftest.tar.gz || exit $?
 cd kselftest
 ./run_kselftest.sh


### PR DESCRIPTION
We download kselftests targz for x86 only.
Let's support more arch.
Add also a test if the archive already exists, for handling a future add
in rootfs generation.