### PR TITLE
Disable ksekftests on ARM

### DIFF
--- a/kselftests.sh
+++ b/kselftests.sh
@@ -22,6 +22,8 @@ if [ ! -e /root/kselftest.tar.gz ];then
 	;;
 	armv7l)
 		KSARCH=arm
+		echo "SKIP: kselftests are disabled on ARM"
+		exit 0
 	;;
 	*)
 		echo "SKIP: no kselftests for $(uname -m) arch"


### PR DESCRIPTION
kselftests fail too many on ARM, disable it for now.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>