### PR TITLE
kselftest: remove ftrace

### DIFF
--- a/kselftests.sh
+++ b/kselftests.sh
@@ -23,4 +23,7 @@ if [ ! -e /root/kselftest.tar.gz ];then
 fi
 tar xzf kselftest.tar.gz || exit $?
 cd kselftest
+# remove ftrace tests
+sed -i 's,.*ftracetest.*,echo "selftests: ftracetest [SKIP]",' run_kselftest.sh
+
 ./run_kselftest.sh


### PR DESCRIPTION
Running ftrace selftests lead to stuck LAVA jobs at least on some
devices.
So skip them
Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>