### PR TITLE
network: do not touch network in case of NBD/NFS

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+echo "DEBUG: gentoo network test"
+
+# if we have booted with either NFS or NBD, DONT TOUCH NETWORK
+grep -q nfsroot /proc/cmdline
+if [ $? -eq 0 ];then
+	echo "INFO: we use a NFS root, do not touch network"
+	exit 0
+fi
+
+grep -q nbd.server /proc/cmdline
+if [ $? -eq 0 ];then
+	echo "INFO: we use a NBD root, do not touch network"
+	exit 0
+fi
+
 # assume only one network card
 ETH=$(ls /sys/class/net |grep -E 'eth|enp')
 


### PR DESCRIPTION
If DUT is booted with rootfs other network (NBD or NFS), the main network
interface should not be touched

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>