### PR TITLE
Do not start network when kernel was started with ip=dhcp

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -15,6 +15,18 @@ if [ $? -eq 0 ];then
 	exit 0
 fi
 
+if grep -q 'ip=dhcp' /proc/cmdline;then
+	echo "INFO: kernel already get an IP via ip=dhcp cmdline"
+	# update resolv.conf from what got kernel
+	grep nameserver /proc/net/pnp > /etc/resolv.conf
+	chmod 644 /etc/resolv.conf
+	exit 0
+fi
+
+# TODO we need a DHCP client to succeed next step
+# but for the moment all boot will be with ip=dhcp so we do need it yet
+# emerge -v busybox
+
 # assume only one network card
 ETH=$(ls /sys/class/net |grep -E 'eth|enp')
 


### PR DESCRIPTION
Starting network need a DHCP client, but stage3 does not have one by
default.
Since all kernel withh be started with ip=dhcp, let's skip starting network in that case.